### PR TITLE
initial KubOS HAL UART API

### DIFF
--- a/kubos-hal/uart.h
+++ b/kubos-hal/uart.h
@@ -44,8 +44,6 @@ typedef enum {
     K_UART6
 } KUARTNum;
 
-typedef void (*KUART_RxHandler) (uint8_t *buf, int len, void *task_woken);
-
 typedef enum {
     K_WORD_LEN_8BIT = 0,
     K_WORD_LEN_9BIT
@@ -72,7 +70,6 @@ typedef struct {
 
     uint8_t rx_queue_len;
     uint8_t tx_queue_len;
-    KUART_RxHandler *rx_handler;
 } KUARTConf;
 
 typedef struct {

--- a/kubos-hal/uart.h
+++ b/kubos-hal/uart.h
@@ -83,42 +83,66 @@ typedef struct {
 } KUART;
 
 KUARTConf k_uart_conf_defaults(void);
-void k_uart_init(int uart, KUARTConf *conf);
+void k_uart_init(KUARTNum uart, KUARTConf *conf);
 void k_uart_console_init(void);
 
-int k_uart_read(int uart, char *ptr, int len);
-int k_uart_write(int uart, char *ptr, int len);
-void k_uart_write_immediate(int uart, char c);
+int k_uart_read(KUARTNum uart, char *ptr, int len);
+int k_uart_write(KUARTNum uart, char *ptr, int len);
+void k_uart_write_immediate(KUARTNum uart, char c);
 
-int k_uart_rx_queue_len(int uart);
-void k_uart_rx_queue_push(int uart, char c, void *task_woken);
+int k_uart_rx_queue_len(KUARTNum uart);
+void k_uart_rx_queue_push(KUARTNum uart, char c, void *task_woken);
 
-inline int k_uart_rx_pin(int uart) {
+inline int k_uart_rx_pin(KUARTNum uart) {
     switch (uart) {
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART1_RX
         case K_UART1: return YOTTA_CFG_HARDWARE_PINS_UART1_RX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART2_RX
         case K_UART2: return YOTTA_CFG_HARDWARE_PINS_UART2_RX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART3_RX
         case K_UART3: return YOTTA_CFG_HARDWARE_PINS_UART3_RX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART4_RX
         case K_UART4: return YOTTA_CFG_HARDWARE_PINS_UART4_RX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART5_RX
         case K_UART5: return YOTTA_CFG_HARDWARE_PINS_UART5_RX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART6_RX
         case K_UART6: return YOTTA_CFG_HARDWARE_PINS_UART6_RX;
+#endif
     }
     return -1;
 }
 
-inline int k_uart_tx_pin(int uart) {
+inline int k_uart_tx_pin(KUARTNum uart) {
     switch (uart) {
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART1_TX
         case K_UART1: return YOTTA_CFG_HARDWARE_PINS_UART1_TX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART2_TX
         case K_UART2: return YOTTA_CFG_HARDWARE_PINS_UART2_TX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART3_TX
         case K_UART3: return YOTTA_CFG_HARDWARE_PINS_UART3_TX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART4_TX
         case K_UART4: return YOTTA_CFG_HARDWARE_PINS_UART4_TX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART5_TX
         case K_UART5: return YOTTA_CFG_HARDWARE_PINS_UART5_TX;
+#endif
+#ifdef YOTTA_CFG_HARDWARE_PINS_UART6_TX
         case K_UART6: return YOTTA_CFG_HARDWARE_PINS_UART6_TX;
+#endif
     }
     return -1;
 }
 
 // private APIs
-KUART* kprv_uart_get(int uart);
-void kprv_uart_dev_init(int uart);
-void kprv_uart_enable_tx_int(int uart);
+KUART* kprv_uart_get(KUARTNum uart);
+void kprv_uart_dev_init(KUARTNum uart);
+void kprv_uart_enable_tx_int(KUARTNum uart);
 #endif

--- a/kubos-hal/uart.h
+++ b/kubos-hal/uart.h
@@ -1,0 +1,124 @@
+/*
+ * KubOS HAL
+ * Copyright (C) 2016 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef K_UART_H
+#define K_UART_H
+
+#include "FreeRTOS.h"
+#include "queue.h"
+#include <stdint.h>
+
+#include "pins.h"
+
+#ifndef K_NUM_UARTS
+#define K_NUM_UARTS YOTTA_CFG_HARDWARE_UARTCOUNT
+#endif
+
+#ifndef K_UART_CONSOLE
+#define K_UART_CONSOLE YOTTA_CFG_HARDWARE_CONSOLE_UART
+#endif
+
+#ifndef K_UART_CONSOLE_BAUDRATE
+#define K_UART_CONSOLE_BAUDRATE YOTTA_CFG_HARDWARE_CONSOLE_BAUDRATE
+#endif
+
+typedef enum {
+    K_UART1 = 0,
+    K_UART2,
+    K_UART3,
+    K_UART4,
+    K_UART5,
+    K_UART6
+} KUARTNum;
+
+typedef void (*KUART_RxHandler) (uint8_t *buf, int len, void *task_woken);
+
+typedef enum {
+    K_WORD_LEN_8BIT = 0,
+    K_WORD_LEN_9BIT
+} KWordLen;
+
+typedef enum {
+    K_STOP_BITS_1 = 0,
+    K_STOP_BITS_1_5,
+    K_STOP_BITS_2
+} KStopBits;
+
+typedef enum {
+    K_PARITY_NONE = 0,
+    K_PARITY_EVEN,
+    K_PARITY_ODD
+} KParity;
+
+typedef struct {
+    const char *dev_path;
+    uint32_t baud_rate;
+    KWordLen word_len;
+    KStopBits stop_bits;
+    KParity parity;
+
+    uint8_t rx_queue_len;
+    uint8_t tx_queue_len;
+    KUART_RxHandler *rx_handler;
+} KUARTConf;
+
+typedef struct {
+    int dev;
+    KUARTConf conf;
+    QueueHandle_t rx_queue;
+    QueueHandle_t tx_queue;
+} KUART;
+
+KUARTConf k_uart_conf_defaults(void);
+void k_uart_init(int uart, KUARTConf *conf);
+void k_uart_console_init(void);
+
+int k_uart_read(int uart, char *ptr, int len);
+int k_uart_write(int uart, char *ptr, int len);
+void k_uart_write_immediate(int uart, char c);
+
+int k_uart_rx_queue_len(int uart);
+void k_uart_rx_queue_push(int uart, char c, void *task_woken);
+
+inline int k_uart_rx_pin(int uart) {
+    switch (uart) {
+        case K_UART1: return YOTTA_CFG_HARDWARE_PINS_UART1_RX;
+        case K_UART2: return YOTTA_CFG_HARDWARE_PINS_UART2_RX;
+        case K_UART3: return YOTTA_CFG_HARDWARE_PINS_UART3_RX;
+        case K_UART4: return YOTTA_CFG_HARDWARE_PINS_UART4_RX;
+        case K_UART5: return YOTTA_CFG_HARDWARE_PINS_UART5_RX;
+        case K_UART6: return YOTTA_CFG_HARDWARE_PINS_UART6_RX;
+    }
+    return -1;
+}
+
+inline int k_uart_tx_pin(int uart) {
+    switch (uart) {
+        case K_UART1: return YOTTA_CFG_HARDWARE_PINS_UART1_TX;
+        case K_UART2: return YOTTA_CFG_HARDWARE_PINS_UART2_TX;
+        case K_UART3: return YOTTA_CFG_HARDWARE_PINS_UART3_TX;
+        case K_UART4: return YOTTA_CFG_HARDWARE_PINS_UART4_TX;
+        case K_UART5: return YOTTA_CFG_HARDWARE_PINS_UART5_TX;
+        case K_UART6: return YOTTA_CFG_HARDWARE_PINS_UART6_TX;
+    }
+    return -1;
+}
+
+// private APIs
+KUART* kprv_uart_get(int uart);
+void kprv_uart_dev_init(int uart);
+void kprv_uart_enable_tx_int(int uart);
+#endif

--- a/source/uart.c
+++ b/source/uart.c
@@ -29,7 +29,7 @@ static inline BaseType_t queue_push(QueueHandle_t *queue, char c,
     }
 }
 
-KUART* kprv_uart_get(int uart)
+KUART* kprv_uart_get(KUARTNum uart)
 {
     return &k_uarts[uart];
 }
@@ -46,7 +46,7 @@ KUARTConf k_uart_conf_defaults(void)
     };
 }
 
-void k_uart_init(int uart, KUARTConf *conf)
+void k_uart_init(KUARTNum uart, KUARTConf *conf)
 {
     KUART *k_uart = &k_uarts[uart];
     memcpy(&k_uart->conf, conf, sizeof(KUARTConf));
@@ -67,7 +67,7 @@ void k_uart_console_init(void)
     k_uart_init(K_UART_CONSOLE, &conf);
 }
 
-int k_uart_read(int uart, char *ptr, int len)
+int k_uart_read(KUARTNum uart, char *ptr, int len)
 {
     int i = 0;
     BaseType_t result;
@@ -82,7 +82,7 @@ int k_uart_read(int uart, char *ptr, int len)
     return i;
 }
 
-int k_uart_write(int uart, char *ptr, int len)
+int k_uart_write(KUARTNum uart, char *ptr, int len)
 {
     int i = 0;
     for (; i < len; i++, ptr++) {
@@ -95,12 +95,12 @@ int k_uart_write(int uart, char *ptr, int len)
     return i;
 }
 
-int k_uart_rx_queue_len(int uart)
+int k_uart_rx_queue_len(KUARTNum uart)
 {
     return (int) uxQueueMessagesWaiting(k_uarts[uart].rx_queue);
 }
 
-void k_uart_rx_queue_push(int uart, char c, void *task_woken)
+void k_uart_rx_queue_push(KUARTNum uart, char c, void *task_woken)
 {
     queue_push(k_uarts[uart].rx_queue, c, 0, task_woken);
 }

--- a/source/uart.c
+++ b/source/uart.c
@@ -1,0 +1,106 @@
+/*
+ * KubOS HAL
+ * Copyright (C) 2016 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "FreeRTOS.h"
+#include "kubos-hal/uart.h"
+
+static KUART k_uarts[K_NUM_UARTS];
+
+static inline BaseType_t queue_push(QueueHandle_t *queue, char c,
+                                    TickType_t timeout, void *task_woken)
+{
+    if (!task_woken) {
+        return xQueueSendToBack(queue, &c, timeout);
+    } else {
+        return xQueueSendToBackFromISR(queue, &c, task_woken);
+    }
+}
+
+KUART* kprv_uart_get(int uart)
+{
+    return &k_uarts[uart];
+}
+
+KUARTConf k_uart_conf_defaults(void)
+{
+    return (KUARTConf) {
+        .baud_rate = YOTTA_CFG_HARDWARE_UARTDEFAULTS_BAUDRATE,
+        .word_len = YOTTA_CFG_HARDWARE_UARTDEFAULTS_WORDLEN,
+        .stop_bits = YOTTA_CFG_HARDWARE_UARTDEFAULTS_STOPBITS,
+        .parity = YOTTA_CFG_HARDWARE_UARTDEFAULTS_PARITY,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UARTDEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UARTDEFAULTS_TXQUEUELEN,
+    };
+}
+
+void k_uart_init(int uart, KUARTConf *conf)
+{
+    KUART *k_uart = &k_uarts[uart];
+    memcpy(&k_uart->conf, conf, sizeof(KUARTConf));
+
+    k_uart->dev = uart;
+    k_uart->rx_queue = xQueueCreate(k_uart->conf.rx_queue_len, sizeof(char));
+    k_uart->tx_queue = xQueueCreate(k_uart->conf.tx_queue_len, sizeof(char));
+
+    kprv_uart_dev_init(uart);
+}
+
+void k_uart_console_init(void)
+{
+    KUARTConf conf = k_uart_conf_defaults();
+    conf.baud_rate = K_UART_CONSOLE_BAUDRATE;
+    // TODO: allow more configuration of console UART device
+
+    k_uart_init(K_UART_CONSOLE, &conf);
+}
+
+int k_uart_read(int uart, char *ptr, int len)
+{
+    int i = 0;
+    BaseType_t result;
+
+    for (; i < len; i++, ptr++) {
+        result = xQueueReceive(k_uarts[uart].rx_queue, ptr, portMAX_DELAY);
+        if (result != pdTRUE) {
+            return i;
+        }
+    }
+
+    return i;
+}
+
+int k_uart_write(int uart, char *ptr, int len)
+{
+    int i = 0;
+    for (; i < len; i++, ptr++) {
+        BaseType_t result = queue_push(k_uarts[uart].tx_queue, *ptr, portMAX_DELAY, NULL);
+        if (result != pdTRUE) {
+            return i;
+        }
+        kprv_uart_enable_tx_int(uart);
+    }
+    return i;
+}
+
+int k_uart_rx_queue_len(int uart)
+{
+    return (int) uxQueueMessagesWaiting(k_uarts[uart].rx_queue);
+}
+
+void k_uart_rx_queue_push(int uart, char c, void *task_woken)
+{
+    queue_push(k_uarts[uart].rx_queue, c, 0, task_woken);
+}


### PR DESCRIPTION
this implementation uses an RX and TX character queue to asynchronously
push data to and from the UART device with interrupts. drivers will
implement the kprv_* family of private functions at the bottom of uart.h

openkosmosorg/kubos-hal-stm32f407vg#1